### PR TITLE
Add date to timestamp in oscrouter log window

### DIFF
--- a/OSCRouter/MainWindow.cpp
+++ b/OSCRouter/MainWindow.cpp
@@ -1662,17 +1662,14 @@ void MainWindow::FlushLogQ(EosLog::LOG_Q &logQ)
 		{
 			const EosLog::sLogMsg logMsg = *i;
 
-			tm *t = localtime( &logMsg.timestamp );
-
+			//tm *t = localtime( &logMsg.timestamp );
+                        QDateTime dt;
+                        dt.setTime_t(logMsg.timestamp);
 			QString msgText;
 			if( logMsg.text.c_str() )
 				msgText = QString::fromUtf8( logMsg.text.c_str() );
-
-			QString itemText = QString("[ %1:%2:%3 ]  %4")
-				.arg(t->tm_hour, 2)
-				.arg(t->tm_min, 2, 10, QChar('0'))
-				.arg(t->tm_sec, 2, 10, QChar('0'))
-				.arg( msgText );
+                        QString dateString = dt.toString("ddd dd MMM yyyy [h:mm:ss]");
+                        QString itemText = QString("%1 %2").arg(dateString, msgText);
 
 			if( m_LogFile.isOpen() )
 			{


### PR DESCRIPTION
Just a quick change, it makes it easier for me to track back through the log.  

Given that we are using Qt already I did adapt this to use a QDateTime for a bit more readability (imo).  I can change it back to working with the time_t directly if you'd prefer.

Separate from this, I do have a separate assortment of changes that make OSCRouter (and more, EosSyncLib) build and run on linux, as well as add cmake files to use CMake as a buildsystem across the platforms.  I'm happy to keep those local, but I'll open a PR if you think it would be a useful addition.  Mostly just changing some preprocessor checks to be more explicit, and moving from long (8 bytes on linux, 4 on windows/osx) to int (4 bytes on all three, currently).  I looked at moving to a more specific variable type, but not sure how the feelings are on c99 in these projects..

Thanks,