### PR TITLE
Fixes macOS issues and updates to 64 bit build on Mac

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -2,6 +2,21 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>.osc.txt</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>OSCRouter Configuration</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSTypeIsPackage</key>
+			<integer>0</integer>
+		</dict>
+	</array>
 	<key>CFBundleExecutable</key>
 	<string>OSCRouter</string>
 	<key>CFBundleGetInfoString</key>
@@ -14,5 +29,7 @@
 	<string>APPL</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
 </dict>
 </plist>

--- a/OSCRouter.xcodeproj/project.pbxproj
+++ b/OSCRouter.xcodeproj/project.pbxproj
@@ -323,7 +323,7 @@
 		4B72B24813252891014BCF61 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				ARCHS = "$(ARCHS_STANDARD)";
 				COPY_PHASE_STRIP = NO;
 				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -376,7 +376,7 @@
 		D70590BEB531B51029F711BB /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				ARCHS = "$(ARCHS_STANDARD)";
 				COPY_PHASE_STRIP = YES;
 				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
 				HEADER_SEARCH_PATHS = (

--- a/OSCRouter/MainWindow.cpp
+++ b/OSCRouter/MainWindow.cpp
@@ -1995,7 +1995,7 @@ void MainWindow::onOpenFileClicked(bool /*checked*/)
 		dir = QFileInfo(lastFile).absolutePath();
 	if(dir.isEmpty() || !QFileInfo(dir).exists())
 		dir = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
-	QString path = QFileDialog::getOpenFileName(this, tr("Open"), dir, tr("OSCRouter File (*.osc.txt)"));
+	QString path = QFileDialog::getOpenFileName(this, tr("Open"), dir, tr("OSCRouter File (*.txt *.osc.txt)"));
 	if( !path.isEmpty() )
 	{
 		if( !LoadFile(path) )


### PR DESCRIPTION
Fixes issue where File Open dialog won't accept any files on macOS due to apparent error in Qt parsing of valid file extensions by adding *.txt as valid.

Fixes lack of retina support.
Updates build architecture to 64 bit, as will soon be required by macOS.